### PR TITLE
nicer add tool modal

### DIFF
--- a/controller/components/tools/NewToolModal.tsx
+++ b/controller/components/tools/NewToolModal.tsx
@@ -217,7 +217,7 @@ export const NewToolModal: React.FC<AddToolCommandModalProps> = (props) => {
                 )}
               </Flex>
               <Box
-                maxH="calc(3 * 130px + 3 * 1rem)" // 3 rows of cards (approx 120px each) + spacing
+                maxH="calc(3 * 140px + 3 * 1rem)" // 3 rows of cards (approx 130px each) + spacing
                 overflowY="auto"
                 pr={2}
                 py={5}>


### PR DESCRIPTION
Update to add new tool modal. 
Grid view w images of tools, limited to 3 rows and scales to different screen sizes, it is also searchable.


<img width="728" alt="image" src="https://github.com/user-attachments/assets/f4a724f4-138a-4b03-aedb-1182d9c88ff9" />
<img width="496" alt="image" src="https://github.com/user-attachments/assets/db7b6d62-a0da-47aa-9475-370d91f21225" />
<img width="370" alt="image" src="https://github.com/user-attachments/assets/31d1a826-3b48-441b-a72a-e997b18c5cd2" />
