### PR TITLE
Public folder not fully copied in standalone build

### DIFF
--- a/.github/workflows/build-nextjs-artifact.yml
+++ b/.github/workflows/build-nextjs-artifact.yml
@@ -76,10 +76,12 @@ jobs:
           mkdir -p ../nextjs-artifact/.next/static
           cp -r .next/static/* ../nextjs-artifact/.next/static/
 
-          # Copy public assets
+          # Copy public assets (remove incomplete standalone public first to avoid merge issues)
           if [ -d "public" ]; then
             echo "Adding public assets..."
+            rm -rf ../nextjs-artifact/public
             cp -r public ../nextjs-artifact/public
+            echo "✓ Public folder copied ($(ls ../nextjs-artifact/public | wc -l) items)"
           fi
 
           # Copy gen-interfaces


### PR DESCRIPTION
The standalone build only traces imported files, so tool_icons (referenced via URL strings) were excluded. When the workflow then copied the full public folder, it failed to properly merge with the existing incomplete public folder on Windows.

Fix: Remove the incomplete standalone public folder before copying the full one to ensure all assets (including tool_icons) are included.