### PR TITLE
fix: timer/modal race conditions with atomic modalState endpoint

### DIFF
--- a/controller/components/runs/RunsComponent.tsx
+++ b/controller/components/runs/RunsComponent.tsx
@@ -109,13 +109,8 @@ export const RunsComponent: React.FC = () => {
   const resumeMutation = trpc.commandQueue.resume.useMutation();
 
   const commandsAll = trpc.commandQueue.getAll.useQuery(undefined, { refetchInterval: 2000 });
-  // Query for waiting-for-input status
-  const isWaitingForInputQuery = trpc.commandQueue.isWaitingForInput.useQuery(undefined, {
-    refetchInterval: 1000,
-  });
-
-  // Query for current message data
-  const currentMessageQuery = trpc.commandQueue.currentMessage.useQuery(undefined, {
+  // Combined modal state query — atomic to prevent race conditions
+  const modalStateQuery = trpc.commandQueue.modalState.useQuery(undefined, {
     refetchInterval: 1000,
   });
 
@@ -161,42 +156,32 @@ export const RunsComponent: React.FC = () => {
   });
 
   useEffect(() => {
-    if (isWaitingForInputQuery.data !== undefined) {
-      const shouldShowModal = isWaitingForInputQuery.data;
-      const shouldShowUserForm = shouldShowModal && messageData.type === "user_form";
+    if (!modalStateQuery.data) return;
 
-      setIsModalOpen(shouldShowModal && messageData.type !== "user_form");
-      setIsUserFormModalOpen(shouldShowUserForm);
+    const { isWaiting, message } = modalStateQuery.data;
+
+    const newMessageData = {
+      type: message.type,
+      message: message.message,
+      ...(message.title ? { title: message.title } : {}),
+      ...(message.pausedAt ? { pausedAt: message.pausedAt } : {}),
+      ...(message.timerDuration ? { timerDuration: message.timerDuration } : {}),
+      ...(message.timerEndTime ? { timerEndTime: message.timerEndTime } : {}),
+      ...(message.formName ? { formName: message.formName } : {}),
+    };
+
+    setMessageData(newMessageData);
+
+    const shouldShowUserForm = isWaiting && message.type === "user_form";
+    setIsModalOpen(isWaiting && message.type !== "user_form");
+    setIsUserFormModalOpen(shouldShowUserForm);
+
+    // Reset form state when message type changes
+    if (message.type !== "user_form") {
+      setCurrentForm(null);
+      setUserFormError(null);
     }
-
-    if (currentMessageQuery.data) {
-      const newMessageData = {
-        type: currentMessageQuery.data.type,
-        message: currentMessageQuery.data.message,
-        ...(currentMessageQuery.data.title ? { title: currentMessageQuery.data.title } : {}),
-        ...(currentMessageQuery.data.pausedAt
-          ? { pausedAt: currentMessageQuery.data.pausedAt }
-          : {}),
-        ...(currentMessageQuery.data.timerDuration
-          ? { timerDuration: currentMessageQuery.data.timerDuration }
-          : {}),
-        ...(currentMessageQuery.data.timerEndTime
-          ? { timerEndTime: currentMessageQuery.data.timerEndTime }
-          : {}),
-        ...(currentMessageQuery.data.formName
-          ? { formName: currentMessageQuery.data.formName }
-          : {}),
-      };
-
-      setMessageData(newMessageData);
-
-      // Reset form state when message type changes
-      if (newMessageData.type !== "user_form") {
-        setCurrentForm(null);
-        setUserFormError(null);
-      }
-    }
-  }, [isWaitingForInputQuery.data, currentMessageQuery.data, messageData.type]);
+  }, [modalStateQuery.data]);
 
   const handleResume = () => {
     resumeMutation.mutate();

--- a/controller/components/runs/TimerModal.tsx
+++ b/controller/components/runs/TimerModal.tsx
@@ -84,44 +84,22 @@ export const TimerModal: React.FC<TimerModalProps> = ({ isOpen, messageData, onS
     }
 
     // Calculate initial state
-    const now = Date.now();
     const endTime = messageData.timerEndTime;
     const duration = messageData.timerDuration || 0;
 
-    // Handle case where timer might already be expired
-    if (now >= endTime) {
-      setRemainingSeconds(0);
-      setProgress(0);
-      setTotalSeconds(Math.ceil(duration / 1000));
-
-      // Call skip after a short delay to avoid render issues
-      setTimeout(() => {
-        if (isActiveRef.current && !hasSkippedRef.current) {
-          handleSkip();
-        }
-      }, 50);
-
-      return;
-    }
-
-    // Set up the update function
+    // Set up the update function — display only, no auto-skip
     const updateTimer = () => {
-      if (!isActiveRef.current || hasSkippedRef.current) return;
+      if (!isActiveRef.current) return;
 
       const currentTime = Date.now();
       const timeLeft = Math.max(0, endTime - currentTime);
       const secondsLeft = Math.ceil(timeLeft / 1000);
       const totalDuration = Math.ceil(duration / 1000);
-      const progressPercent = Math.max(0, Math.min(100, (timeLeft / duration) * 100));
+      const progressPercent = duration > 0 ? Math.max(0, Math.min(100, (timeLeft / duration) * 100)) : 0;
 
       setRemainingSeconds(secondsLeft);
       setTotalSeconds(totalDuration);
       setProgress(progressPercent);
-
-      // Auto-complete when timer ends
-      if (secondsLeft <= 0 && isActiveRef.current && !hasSkippedRef.current) {
-        setTimeout(handleSkip, 50);
-      }
     };
 
     // Initial update
@@ -138,7 +116,7 @@ export const TimerModal: React.FC<TimerModalProps> = ({ isOpen, messageData, onS
         timerRef.current = null;
       }
     };
-  }, [isOpen, messageData.timerEndTime, messageData.timerDuration, onSkip]);
+  }, [isOpen, messageData.timerEndTime, messageData.timerDuration]);
 
   // Don't render if not open
   if (!isOpen) return null;

--- a/controller/components/runs/TimerModal.tsx
+++ b/controller/components/runs/TimerModal.tsx
@@ -95,7 +95,8 @@ export const TimerModal: React.FC<TimerModalProps> = ({ isOpen, messageData, onS
       const timeLeft = Math.max(0, endTime - currentTime);
       const secondsLeft = Math.ceil(timeLeft / 1000);
       const totalDuration = Math.ceil(duration / 1000);
-      const progressPercent = duration > 0 ? Math.max(0, Math.min(100, (timeLeft / duration) * 100)) : 0;
+      const progressPercent =
+        duration > 0 ? Math.max(0, Math.min(100, (timeLeft / duration) * 100)) : 0;
 
       setRemainingSeconds(secondsLeft);
       setTotalSeconds(totalDuration);

--- a/controller/server/command_queue.ts
+++ b/controller/server/command_queue.ts
@@ -329,6 +329,7 @@ export class CommandQueue {
 
       // Reset the state
       this._isWaitingForInput = false;
+      this._currentMessage = { type: "pause", message: "" };
 
       // Add a small delay to ensure all state updates have propagated
       await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/controller/server/routers/command_queue.ts
+++ b/controller/server/routers/command_queue.ts
@@ -126,4 +126,15 @@ export const commandQueueRouter = router({
       ...(message.formName ? { formName: message.formName } : {}),
     };
   }),
+
+  modalState: procedure.query(async () => {
+    const message = CommandQueue.global.currentMessage;
+    return {
+      isWaiting: CommandQueue.global.isWaitingForInput,
+      message: {
+        ...message,
+        ...(message.formName ? { formName: message.formName } : {}),
+      },
+    };
+  }),
 });


### PR DESCRIPTION
## Summary
- Add combined `modalState` endpoint that returns both `isWaiting` and `message` data atomically, preventing race conditions where the UI could see stale state
- Remove frontend auto-skip logic from TimerModal — the server is now the sole timer authority
- Clear stale message data in `_ensureModalReady` to prevent ghost modals on resume

## Context
This is PR 4 of 6 from the `clariostar-and-lcus1-integration` branch split. Fully independent — can be reviewed and merged in any order.

## Test plan
- [x] Start a run with timer commands — verify timer modal shows and counts down correctly
- [x] Verify no phantom modals appear after resuming from a pause
- [x] Verify the modal state updates atomically (no flicker between waiting/message states)
- [x] Run `bin/make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)