### PR TITLE
feat: protocol import/export with JSON

### DIFF
--- a/controller/components/protocols/ProtocolDetailView.tsx
+++ b/controller/components/protocols/ProtocolDetailView.tsx
@@ -20,9 +20,10 @@ import {
   MenuList,
   MenuItem,
   Center,
+  Input,
 } from "@chakra-ui/react";
 import { DeleteIcon, AddIcon, EditIcon, ArrowForwardIcon, HamburgerIcon } from "@chakra-ui/icons";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   DragDropContext,
   Droppable,
@@ -37,13 +38,13 @@ import { AddToolCommandModal } from "./AddToolCommandModal";
 import NewProtocolRunModal from "./NewProtocolRunModal";
 import { trpc } from "@/utils/trpc";
 import { capitalizeFirst } from "@/utils/parser";
-import { Play, Download, LogOut } from "lucide-react";
+import { Play, Download, LogOut, Upload } from "lucide-react";
 
 import { ConfirmationModal } from "../ui/ConfirmationModal";
 import { SaveIcon } from "@/components/ui/Icons";
 import { CommandDetailsDrawer } from "./CommandDetailsDrawer";
 import CommandImage from "@/components/tools/CommandImage";
-import { successToast, errorToast } from "../ui/Toast";
+import { successToast, errorToast, warningToast } from "../ui/Toast";
 import ProtocolParametersEditor from "./ProtocolParametersEditor";
 import type { ProtocolParameter } from "@/protocols/params";
 
@@ -144,6 +145,8 @@ export const ProtocolDetailView: React.FC<{ id: number }> = ({ id }) => {
   const [isRunModalOpen, setIsRunModalOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const importFileInputRef = useRef<HTMLInputElement>(null);
   const [addCommandPosition, setAddCommandPosition] = useState<number | null>(null);
   const [selectedCommand, setSelectedCommand] = useState<any | null>(null);
   const { isOpen: isDrawerOpen, onOpen: onDrawerOpen, onClose: onDrawerClose } = useDisclosure();
@@ -304,6 +307,52 @@ export const ProtocolDetailView: React.FC<{ id: number }> = ({ id }) => {
       errorToast("Export Failed", error.message || "Failed to export protocol");
     } finally {
       setIsExporting(false);
+    }
+  };
+
+  const handleImportClick = () => {
+    importFileInputRef.current?.click();
+  };
+
+  const handleImportFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      setIsImporting(true);
+      const fileContent = await file.text();
+      const data = JSON.parse(fileContent);
+
+      // Validate basic structure (exported format wraps in { protocol: {...} })
+      const protocolData = data.protocol ?? data;
+      if (!protocolData.commands || !Array.isArray(protocolData.commands)) {
+        errorToast("Invalid file", "The JSON file does not contain a valid protocol.");
+        return;
+      }
+
+      // Warn if names don't match
+      if (protocol && protocolData.name && protocolData.name !== protocol.name) {
+        warningToast(
+          "Name mismatch",
+          `Imported protocol name "${protocolData.name}" differs from "${protocol.name}". Keeping existing name.`,
+        );
+      }
+
+      // Update existing protocol — keep current name, overwrite content
+      await updateProtocol.mutateAsync({
+        id,
+        category: protocolData.category ?? protocol?.category,
+        description: protocolData.description ?? protocol?.description ?? null,
+        commands: protocolData.commands ?? protocol?.commands,
+        parameters: protocolData.parameters ?? protocol?.parameters ?? null,
+      });
+    } catch (error: any) {
+      errorToast("Import failed", error.message || "Could not parse the JSON file.");
+    } finally {
+      setIsImporting(false);
+      if (importFileInputRef.current) {
+        importFileInputRef.current.value = "";
+      }
     }
   };
 
@@ -500,6 +549,14 @@ export const ProtocolDetailView: React.FC<{ id: number }> = ({ id }) => {
                   Export
                 </Button>
                 <Button
+                  leftIcon={<Upload />}
+                  colorScheme="blue"
+                  variant="outline"
+                  onClick={handleImportClick}
+                  isLoading={isImporting}>
+                  Import
+                </Button>
+                <Button
                   leftIcon={<EditIcon />}
                   colorScheme="teal"
                   onClick={() => setIsEditing(true)}>
@@ -575,6 +632,14 @@ export const ProtocolDetailView: React.FC<{ id: number }> = ({ id }) => {
         onClose={closeDeleteConfirm}>
         {`Are you sure you want to delete this command "${selectedCommand?.commandInfo?.command?.replaceAll("_", " ") || ""}"?`}
       </ConfirmationModal>
+
+      <Input
+        type="file"
+        ref={importFileInputRef}
+        onChange={handleImportFileChange}
+        style={{ display: "none" }}
+        accept=".json"
+      />
     </Box>
   );
 };

--- a/controller/components/protocols/ProtocolDetailView.tsx
+++ b/controller/components/protocols/ProtocolDetailView.tsx
@@ -345,6 +345,8 @@ export const ProtocolDetailView: React.FC<{ id: number }> = ({ id }) => {
         description: protocolData.description ?? protocol?.description ?? null,
         commands: protocolData.commands ?? protocol?.commands,
         parameters: protocolData.parameters ?? protocol?.parameters ?? null,
+        mode: protocolData.mode ?? protocol?.mode,
+        scriptContent: protocolData.scriptContent ?? protocol?.scriptContent ?? null,
       });
     } catch (error: any) {
       errorToast("Import failed", error.message || "Could not parse the JSON file.");

--- a/controller/components/protocols/ProtocolDetailView.tsx
+++ b/controller/components/protocols/ProtocolDetailView.tsx
@@ -345,8 +345,6 @@ export const ProtocolDetailView: React.FC<{ id: number }> = ({ id }) => {
         description: protocolData.description ?? protocol?.description ?? null,
         commands: protocolData.commands ?? protocol?.commands,
         parameters: protocolData.parameters ?? protocol?.parameters ?? null,
-        mode: protocolData.mode ?? protocol?.mode,
-        scriptContent: protocolData.scriptContent ?? protocol?.scriptContent ?? null,
       });
     } catch (error: any) {
       errorToast("Import failed", error.message || "Could not parse the JSON file.");

--- a/controller/components/protocols/ProtocolPageComponent.tsx
+++ b/controller/components/protocols/ProtocolPageComponent.tsx
@@ -142,6 +142,8 @@ export const ProtocolPageComponent: React.FC = () => {
           description: protocolData.description,
           commands: protocolData.commands,
           parameters: protocolData.parameters,
+          mode: protocolData.mode,
+          scriptContent: protocolData.scriptContent,
         },
       });
     } catch (error: any) {

--- a/controller/components/protocols/ProtocolPageComponent.tsx
+++ b/controller/components/protocols/ProtocolPageComponent.tsx
@@ -44,12 +44,12 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import { SearchIcon, ArrowUpDownIcon, HamburgerIcon, DeleteIcon } from "@chakra-ui/icons";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 import Link from "next/link";
 import NewProtocolRunModal from "./NewProtocolRunModal";
 import { trpc } from "@/utils/trpc";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { GitBranch, Plus, Play } from "lucide-react";
+import { GitBranch, Plus, Play, Upload } from "lucide-react";
 import { EditableText } from "../ui/Form";
 import { errorToast, successToast } from "../ui/Toast";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -87,6 +87,71 @@ export const ProtocolPageComponent: React.FC = () => {
       errorToast("Error deleting protocol", error.message);
     },
   });
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const importMutation = trpc.protocol.import.useMutation({
+    onSuccess: () => {
+      successToast("Protocol imported", "Protocol has been created successfully.");
+      refetch();
+    },
+  });
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImportFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const fileContent = await file.text();
+      const data = JSON.parse(fileContent);
+
+      // Validate basic structure (exported format wraps in { protocol: {...} })
+      const protocolData = data.protocol ?? data;
+      if (!protocolData.name) {
+        errorToast("Invalid file", "The JSON file does not contain a valid protocol.");
+        return;
+      }
+
+      // Check for duplicate name in current workcell
+      const existingProtocol = protocols?.find(
+        (p) => p.name.toLowerCase() === protocolData.name.toLowerCase(),
+      );
+      if (existingProtocol) {
+        errorToast(
+          "Protocol already exists",
+          `A protocol named "${protocolData.name}" already exists. Rename it in the JSON file, or navigate to the existing protocol to update it.`,
+        );
+        return;
+      }
+
+      // Find workcellId from workcellName
+      const selectedWorkcell = workcells?.find((w) => w.name === workcellName);
+      if (!selectedWorkcell) {
+        errorToast("No workcell selected", "Please select a workcell before importing.");
+        return;
+      }
+
+      await importMutation.mutateAsync({
+        workcellId: selectedWorkcell.id,
+        protocol: {
+          name: protocolData.name,
+          category: protocolData.category,
+          description: protocolData.description,
+          commands: protocolData.commands,
+          parameters: protocolData.parameters,
+        },
+      });
+    } catch (error: any) {
+      errorToast("Import failed", error.message || "Could not parse the JSON file.");
+    } finally {
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
 
   const updateProtocol = trpc.protocol.update.useMutation({
     onSuccess: () => {
@@ -206,6 +271,21 @@ export const ProtocolPageComponent: React.FC = () => {
               titleIcon={<Icon as={GitBranch} boxSize={8} color="teal.500" />}
               mainButton={
                 <HStack>
+                  <Tooltip
+                    label={!workcellName ? "Create or Select a Workcell to import a protocol" : ""}
+                    placement="top"
+                    hasArrow>
+                    <Button
+                      size="sm"
+                      isDisabled={!workcellName}
+                      colorScheme="blue"
+                      variant="outline"
+                      leftIcon={<Upload size={14} />}
+                      onClick={handleImportClick}
+                      isLoading={importMutation.isLoading}>
+                      Import
+                    </Button>
+                  </Tooltip>
                   <Tooltip
                     label={!workcellName ? "Create or Select a Workcell to create a protocol" : ""}
                     placement="top"
@@ -456,6 +536,14 @@ export const ProtocolPageComponent: React.FC = () => {
           </ModalBody>
         </ModalContent>
       </Modal>
+
+      <Input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleImportFileChange}
+        style={{ display: "none" }}
+        accept=".json"
+      />
     </VStack>
   );
 };

--- a/controller/components/protocols/ProtocolPageComponent.tsx
+++ b/controller/components/protocols/ProtocolPageComponent.tsx
@@ -142,8 +142,6 @@ export const ProtocolPageComponent: React.FC = () => {
           description: protocolData.description,
           commands: protocolData.commands,
           parameters: protocolData.parameters,
-          mode: protocolData.mode,
-          scriptContent: protocolData.scriptContent,
         },
       });
     } catch (error: any) {

--- a/controller/server/routers/workcell.ts
+++ b/controller/server/routers/workcell.ts
@@ -21,6 +21,7 @@ import {
 import { eq } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { logAuditEvent } from "@/server/utils/auditLog";
+import { zProtocolParameter } from "@/protocols/params";
 
 export const zWorkcell = z.object({
   id: z.number().optional(),
@@ -384,11 +385,12 @@ export const workcellRouter = router({
         type,
         value: "", // Empty value on export for security
       })),
-      protocols: workcellProtocols.map(({ name, category, description, commands }) => ({
+      protocols: workcellProtocols.map(({ name, category, description, commands, parameters }) => ({
         name,
         category,
         description,
         commands,
+        parameters: parameters ?? null,
       })),
       scriptFolders: workcellScriptFolders.map((folder) => ({
         name: folder.name,
@@ -544,6 +546,7 @@ export const workcellRouter = router({
               category: z.string().nullable().optional(),
               description: z.string().nullable().optional(),
               commands: z.any().optional(),
+              parameters: z.array(zProtocolParameter).nullable().optional(),
             }),
           )
           .optional(),
@@ -766,6 +769,7 @@ export const workcellRouter = router({
             category: p.category ?? "",
             description: p.description ?? null,
             commands: p.commands ?? [],
+            parameters: p.parameters ?? null,
             workcellId: newWorkcell.id,
           })),
         );


### PR DESCRIPTION
## Summary
- Add protocol import button to both protocol list page and protocol detail page
- Add file upload handler with JSON validation and duplicate name checking
- Include run parameters in workcell JSON schema export/import
- Fix import handler edge cases

## Context
This is PR 6 of 6 from the `clariostar-and-lcus1-integration` branch split. Can be reviewed independently, but for full mode/scriptContent support in import/export, depends on PR #209 (script-based protocols).

## Dependencies
- Depends on #209 (script-based protocols) for `mode`/`scriptContent` field support in import/export

## Test plan
- [x] Export a protocol from the detail page — verify JSON contains commands and parameters
- [x] Import a protocol JSON from the list page — verify it creates correctly
- [x] Import a protocol JSON from the detail page — verify it overwrites content
- [x] Try importing invalid JSON — verify error handling
- [x] Run `bin/make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)