### PR TITLE
Add general-purpose webhook system

### DIFF
--- a/controller/db/migrations/0010_add_webhooks.sql
+++ b/controller/db/migrations/0010_add_webhooks.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `webhooks` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`url` text NOT NULL,
+	`tool_types` text,
+	`commands` text,
+	`include_data` integer DEFAULT true NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL
+);

--- a/controller/db/migrations/meta/_journal.json
+++ b/controller/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1772050718802,
       "tag": "0009_dapper_ink",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1774857600000,
+      "tag": "0010_add_webhooks",
+      "breakpoints": true
     }
   ]
 }

--- a/controller/db/schema/index.ts
+++ b/controller/db/schema/index.ts
@@ -314,6 +314,17 @@ export const logs = sqliteTable("logs", {
   ...timestamps,
 });
 
+export const webhooks = sqliteTable("webhooks", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  url: text("url").notNull(),
+  toolTypes: text("tool_types", { mode: "json" }).$type<string[] | null>(),
+  commands: text("commands", { mode: "json" }).$type<string[] | null>(),
+  includeData: integer("include_data", { mode: "boolean" }).notNull().default(true),
+  isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
+  ...timestamps,
+});
+
 // TypeScript Types
 export type Workcell = typeof workcells.$inferSelect;
 export type NewWorkcell = typeof workcells.$inferInsert;
@@ -359,6 +370,8 @@ export type RobotArmGripParams = typeof robotArmGripParams.$inferSelect;
 export type NewRobotArmGripParams = typeof robotArmGripParams.$inferInsert;
 export type Log = typeof logs.$inferSelect;
 export type NewLog = typeof logs.$inferInsert;
+export type Webhook = typeof webhooks.$inferSelect;
+export type NewWebhook = typeof webhooks.$inferInsert;
 
 export const schema = {
   workcells,
@@ -383,4 +396,5 @@ export const schema = {
   robotArmMotionProfiles,
   robotArmGripParams,
   logs,
+  webhooks,
 };

--- a/controller/server/command_queue.ts
+++ b/controller/server/command_queue.ts
@@ -12,6 +12,7 @@ import { db } from "@/db/client";
 import { appSettings, variables, workcells } from "@/db/schema";
 import { and, eq } from "drizzle-orm";
 import { sendEmailMessage, sendSlackMessage } from "@/server/utils/integrationsLocal";
+import { dispatchWebhooks } from "@/server/utils/webhookDispatch";
 
 export type CommandQueueState = ToolStatus;
 
@@ -384,8 +385,9 @@ export class CommandQueue {
   }
 
   async executeCommand(command: StoredRunCommand) {
-    await Tool.executeCommand(command.commandInfo);
+    const reply = await Tool.executeCommand(command.commandInfo);
     await this.commands.complete(command.queueId);
+    return reply;
   }
 
   async skipCommand(commandId: number) {
@@ -1011,7 +1013,7 @@ export class CommandQueue {
         }
 
         // Regular command, send to Tool
-        await this.executeCommand(nextCommand);
+        const reply = await this.executeCommand(nextCommand);
 
         logAction({
           level: "info",
@@ -1019,6 +1021,19 @@ export class CommandQueue {
           details: "Command executed successfully.",
         });
         logger.info("Command executed successfully");
+
+        // Fire webhooks (async, non-blocking)
+        dispatchWebhooks({
+          event: "command.completed",
+          timestamp: new Date().toISOString(),
+          runId: nextCommand.runId,
+          toolType: nextCommand.commandInfo?.toolType ?? "",
+          toolId: nextCommand.commandInfo?.toolId ?? "",
+          command: nextCommand.commandInfo?.command ?? "",
+          status: "SUCCESS",
+          params: nextCommand.commandInfo?.params ?? {},
+          data: reply?.meta_data?.data ?? null,
+        }).catch(() => {});
       } catch (e) {
         logger.error("Failed to execute command", e);
 
@@ -1046,6 +1061,19 @@ export class CommandQueue {
           command: nextCommand.commandInfo?.command,
           label: nextCommand.commandInfo?.label,
         });
+
+        // Fire webhooks for failure (async, non-blocking)
+        dispatchWebhooks({
+          event: "command.failed",
+          timestamp: new Date().toISOString(),
+          runId: nextCommand.runId,
+          toolType: nextCommand.commandInfo?.toolType ?? "",
+          toolId: nextCommand.commandInfo?.toolId ?? "",
+          command: nextCommand.commandInfo?.command ?? "",
+          status: "FAILED",
+          params: nextCommand.commandInfo?.params ?? {},
+          errorMessage: this.error?.message,
+        }).catch(() => {});
 
         // Exit the busy loop but keep the error state
         break;

--- a/controller/server/routers/_app.ts
+++ b/controller/server/routers/_app.ts
@@ -19,6 +19,7 @@ import { auditRouter } from "./audit";
 import { backupRouter } from "./backup";
 import { hubLibraryRouter } from "./hubLibrary";
 import { appSettingsRouter } from "./appSettings";
+import { webhooksRouter } from "./webhooks";
 
 export const appRouter = router({
   inventory: inventoryRouter,
@@ -41,6 +42,7 @@ export const appRouter = router({
   form: formRouter,
   hubLibrary: hubLibraryRouter,
   appSettings: appSettingsRouter,
+  webhooks: webhooksRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/controller/server/routers/webhooks.ts
+++ b/controller/server/routers/webhooks.ts
@@ -1,0 +1,90 @@
+import { procedure, router } from "@/server/trpc";
+import { db } from "@/db/client";
+import { webhooks } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { logAuditEvent } from "@/server/utils/auditLog";
+
+export const webhooksRouter = router({
+  list: procedure.query(async () => {
+    return db.select().from(webhooks);
+  }),
+
+  create: procedure
+    .input(
+      z.object({
+        name: z.string().min(1),
+        url: z.string().url(),
+        toolTypes: z.array(z.string()).nullable().optional(),
+        commands: z.array(z.string()).nullable().optional(),
+        includeData: z.boolean().optional(),
+        isActive: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const created = await db
+        .insert(webhooks)
+        .values({
+          name: input.name,
+          url: input.url,
+          toolTypes: input.toolTypes ?? null,
+          commands: input.commands ?? null,
+          includeData: input.includeData ?? true,
+          isActive: input.isActive ?? true,
+        })
+        .returning();
+
+      await logAuditEvent({
+        actor: "user",
+        action: "webhooks.create",
+        targetType: "webhook",
+        targetName: input.name,
+        details: { url: input.url },
+      });
+
+      return created[0];
+    }),
+
+  update: procedure
+    .input(
+      z.object({
+        id: z.number(),
+        name: z.string().min(1).optional(),
+        url: z.string().url().optional(),
+        toolTypes: z.array(z.string()).nullable().optional(),
+        commands: z.array(z.string()).nullable().optional(),
+        includeData: z.boolean().optional(),
+        isActive: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const { id, ...updates } = input;
+      const updated = await db
+        .update(webhooks)
+        .set(updates)
+        .where(eq(webhooks.id, id))
+        .returning();
+
+      await logAuditEvent({
+        actor: "user",
+        action: "webhooks.update",
+        targetType: "webhook",
+        details: { id, ...updates },
+      });
+
+      return updated[0];
+    }),
+
+  delete: procedure
+    .input(z.object({ id: z.number() }))
+    .mutation(async ({ input }) => {
+      await db.delete(webhooks).where(eq(webhooks.id, input.id));
+
+      await logAuditEvent({
+        actor: "user",
+        action: "webhooks.delete",
+        targetType: "webhook",
+        details: { id: input.id },
+      });
+    }),
+});

--- a/controller/server/tools.ts
+++ b/controller/server/tools.ts
@@ -587,6 +587,9 @@ export default class Tool {
         reply.response,
       );
     }
+
+    // Always return the reply so callers can access meta_data
+    return reply;
   }
 
   async estimateDuration(command: ToolCommandInfo) {

--- a/controller/server/utils/webhookDispatch.ts
+++ b/controller/server/utils/webhookDispatch.ts
@@ -1,0 +1,87 @@
+import { db } from "@/db/client";
+import { webhooks } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { logAuditEvent } from "@/server/utils/auditLog";
+import { logAction } from "@/server/logger";
+
+export interface WebhookPayload {
+  event: "command.completed" | "command.failed";
+  timestamp: string;
+  runId: string;
+  toolType: string;
+  toolId: string;
+  command: string;
+  status: string;
+  params: Record<string, any>;
+  data?: string | null;
+  errorMessage?: string;
+}
+
+export async function dispatchWebhooks(payload: WebhookPayload): Promise<void> {
+  let activeWebhooks;
+  try {
+    activeWebhooks = await db
+      .select()
+      .from(webhooks)
+      .where(eq(webhooks.isActive, true));
+  } catch (e) {
+    logAction({
+      level: "error",
+      action: "Webhook Dispatch Error",
+      details: `Failed to fetch webhooks: ${e}`,
+    });
+    return;
+  }
+
+  for (const webhook of activeWebhooks) {
+    if (webhook.toolTypes && !webhook.toolTypes.includes(payload.toolType)) {
+      continue;
+    }
+    if (webhook.commands && !webhook.commands.includes(payload.command)) {
+      continue;
+    }
+
+    const body = webhook.includeData
+      ? payload
+      : { ...payload, data: undefined };
+
+    fireWebhook(webhook.url, webhook.name, body).catch(() => {});
+  }
+}
+
+async function fireWebhook(
+  url: string,
+  name: string,
+  body: Record<string, any>,
+): Promise<void> {
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!resp.ok) {
+      logAction({
+        level: "warning",
+        action: "Webhook Delivery Failed",
+        details: `Webhook "${name}" to ${url} returned ${resp.status}`,
+      });
+    }
+
+    await logAuditEvent({
+      actor: "system",
+      action: "webhooks.dispatch",
+      targetType: "webhook",
+      targetName: name,
+      details: { url, status: resp.status },
+    });
+  } catch (e) {
+    logAction({
+      level: "warning",
+      action: "Webhook Delivery Error",
+      details: `Webhook "${name}" to ${url} failed: ${e instanceof Error ? e.message : e}`,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a configurable webhook system that fires HTTP POSTs on command completion/failure
- Webhooks are registered via a new tRPC CRUD router (`webhooks.list`, `webhooks.create`, `webhooks.update`, `webhooks.delete`)
- Webhooks can filter by tool type and command name, with optional data inclusion
- Fire-and-forget: webhook dispatch is async and never blocks protocol execution

## Components
1. **Database schema** — new `webhooks` table (Drizzle ORM + migration)
2. **Dispatch utility** (`webhookDispatch.ts`) — queries active webhooks, filters, fires POSTs with 10s timeout
3. **Command queue integration** — captures gRPC reply data and dispatches webhooks after command success/failure
4. **tRPC router** — full CRUD with Zod validation and audit logging

## Webhook payload format
```json
{
  "event": "command.completed",
  "timestamp": "2026-03-30T14:30:00Z",
  "runId": "run_abc123",
  "toolType": "clariostar",
  "toolId": "plate_reader_1",
  "command": "StartRead",
  "status": "SUCCESS",
  "params": { "protocol_name": "Lime_384", "plate_id": "13601" },
  "data": "A01,127150\nA02,147026\n..."
}
```

## Test plan
- [ ] Verify TypeScript compiles (`npx tsc --noEmit`)
- [ ] Run migration on fresh database
- [ ] Create a webhook via tRPC, verify it appears in list
- [ ] Execute a tool command and verify webhook is fired to registered URL
- [ ] Verify webhook dispatch does not block command execution
- [ ] Verify failed commands also trigger webhooks with `command.failed` event
- [ ] Verify filtering by tool type and command name works

🤖 Generated with [Claude Code](https://claude.com/claude-code)